### PR TITLE
Test to demonstrate invalid Plugin Manager configuration

### DIFF
--- a/src/Table/DecoratorManager.php
+++ b/src/Table/DecoratorManager.php
@@ -39,7 +39,7 @@ class DecoratorManager extends AbstractPluginManager
         Decorator\Ascii::class          => InvokableFactory::class,
         Decorator\Unicode::class        => InvokableFactory::class,
         Decorator\Blank::class          => InvokableFactory::class,
-        'zendtexttabledecoratorascii'   => InvokableFactory::class,
+        // 'zendtexttabledecoratorascii'   => InvokableFactory::class,
         'zendtexttabledecoratorblank'   => InvokableFactory::class,
         'zendtexttabledecoratorunicode' => InvokableFactory::class,
     ];

--- a/test/Table/DecoratorManagerTest.php
+++ b/test/Table/DecoratorManagerTest.php
@@ -38,7 +38,7 @@ class DecoratorManagerTest extends TestCase
     {
         $pluginManager = $this->getPluginManager();
 
-        self::assertTrue($pluginManager->has('zendtexttabledecoratorascii'));
-        self::assertInstanceOf(Ascii::class, $pluginManager->get('zendtexttabledecoratorascii'));
+        self::assertTrue($pluginManager->has(Ascii::class));
+        self::assertInstanceOf(Ascii::class, $pluginManager->get(Ascii::class));
     }
 }

--- a/test/Table/DecoratorManagerTest.php
+++ b/test/Table/DecoratorManagerTest.php
@@ -10,6 +10,7 @@ namespace ZendTest\Text\Table;
 use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+use Zend\Text\Table\Decorator\Ascii;
 use Zend\Text\Table\Decorator\DecoratorInterface;
 use Zend\Text\Table\DecoratorManager;
 use Zend\Text\Table\Exception\InvalidDecoratorException;
@@ -31,5 +32,13 @@ class DecoratorManagerTest extends TestCase
     protected function getInstanceOf()
     {
         return DecoratorInterface::class;
+    }
+
+    public function testPluginManagerFactories()
+    {
+        $pluginManager = $this->getPluginManager();
+
+        self::assertTrue($pluginManager->has('zendtexttabledecoratorascii'));
+        self::assertInstanceOf(Ascii::class, $pluginManager->get('zendtexttabledecoratorascii'));
     }
 }


### PR DESCRIPTION
@weierophinney I think in many components we do have invalid Plugin Manager configuration - see:

https://github.com/zendframework/zend-text/blob/master/src/Table/DecoratorManager.php#L42-L44

and test I have added in this PR.

I believe these aliases should be added into `$aliases` property.

In the current state these "aliases" are not usable.