### PR TITLE
License URL fixed

### DIFF
--- a/src/Figlet/zend-framework.flf
+++ b/src/Figlet/zend-framework.flf
@@ -12,7 +12,7 @@ Version: 1.0
  This source file is subject to the new BSD license that is bundled
  with this package in the file LICENSE.txt.
  It is also available through the world-wide-web at this URL:
- http://framework.zend.com/license/new-bsd
+ https://framework.zend.com/license
  If you did not receive a copy of the license and are unable to
  obtain it through the world-wide-web, please send an email
  to license@zend.com so we can send you a copy immediately.


### PR DESCRIPTION
License URL was 404. It's fixed now with updated URL